### PR TITLE
feat(core): Linux-first Modules/ path, subdir-aware generators, and m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,15 @@ php artisan module:route-list {name}                     # List module routes
 ### 🛠️ Available Commands
 
 #### Module Management
+- `module:marketplace` - Manage modules via marketplace
+  - Usage: `php artisan module:marketplace {action} {module*} [--force]`
+  - Actions:
+    - `list` (no module args required) → Lists available/installed modules
+    - `install {module...}` → Installs/enables modules
+    - `remove {module...} [--force]` → Removes modules (use --force to bypass checks)
+    - `update {module...}` → Updates modules
+    - `cleanup` → Cleans orphaned module states
+
 - `module:make` - Create a new module
 - `module:enable` - Enable a module
 - `module:disable` - Disable a module

--- a/src/Config/config.php
+++ b/src/Config/config.php
@@ -86,5 +86,6 @@ return array (
     17 => 'Demo3',
     18 => 'Demo4',
     19 => 'Colleger',
+    20 => 'UserManagement',
   ),
 );

--- a/src/Console/Commands/Actions/ModuleCheckLangCommand.php
+++ b/src/Console/Commands/Actions/ModuleCheckLangCommand.php
@@ -24,7 +24,7 @@ class ModuleCheckLangCommand extends Command
     public function handle()
     {
         $module = $this->argument('module');
-        $basePath = base_path("modules/$module/Resources/lang");
+        $basePath = base_path("Modules/$module/Resources/lang");
         if (! $this->files->isDirectory($basePath)) {
             return $this->warn("No lang directory found in module $module.");
         }

--- a/src/Console/Commands/Actions/ModuleDisableCommand.php
+++ b/src/Console/Commands/Actions/ModuleDisableCommand.php
@@ -25,7 +25,7 @@ class ModuleDisableCommand extends Command
 
         foreach ($names as $name) {
             $this->info("Disabling module [{$name}]...");
-            $modulePath = base_path("modules/{$name}");
+            $modulePath = base_path("Modules/{$name}");
 
             try {
                 if (!File::exists($modulePath)) {
@@ -73,7 +73,7 @@ class ModuleDisableCommand extends Command
                     foreach ($migrations as $migration) {
                         try {
                             $this->call('migrate:rollback', [
-                                '--path' => "modules/{$name}/src/Database/Migrations/{$migration}"
+                                '--path' => "Modules/{$name}/src/Database/Migrations/{$migration}"
                             ]);
                             $rolledBack[] = $migration;
                         } catch (\Exception $e) {
@@ -122,7 +122,7 @@ class ModuleDisableCommand extends Command
     protected function checkDependencies($name)
     {
         $dependentModules = [];
-        $modules = File::directories(base_path('modules'));
+        $modules = File::directories(base_path('Modules'));
 
         foreach ($modules as $path) {
             $composerJson = "{$path}/composer.json";
@@ -139,7 +139,7 @@ class ModuleDisableCommand extends Command
 
     protected function removeFromModulesConfig($name)
     {
-        $configPath = base_path('modules/Core/src/Config/modules.php');
+        $configPath = base_path('Modules/Core/src/Config/modules.php');
         if (!File::exists($configPath)) return;
 
         $config = require $configPath;
@@ -172,7 +172,7 @@ class ModuleDisableCommand extends Command
 
     protected function updateModuleJsonState($name)
     {
-        $path = base_path("modules/{$name}/module.json");
+        $path = base_path("Modules/{$name}/module.json");
         if (!File::exists($path)) return;
 
         $json = json_decode(File::get($path), true);

--- a/src/Console/Commands/Actions/ModuleEnableCommand.php
+++ b/src/Console/Commands/Actions/ModuleEnableCommand.php
@@ -21,7 +21,7 @@ class ModuleEnableCommand extends Command
             $this->info("Enabling module [{$name}]...");
 
             try {
-                $modulePath = base_path("modules/{$name}");
+                $modulePath = base_path("Modules/{$name}");
                 $isVendor = false;
 
                 if (!File::exists($modulePath)) {

--- a/src/Console/Commands/Actions/ModuleMarketplaceCommand.php
+++ b/src/Console/Commands/Actions/ModuleMarketplaceCommand.php
@@ -100,7 +100,7 @@ class ModuleMarketplaceCommand extends Command
             $this->runComposerDumpAutoload();
 
             $this->info('Running migrations...');
-            $migrationsPath = base_path("modules/{$name}/src/Database/Migrations");
+            $migrationsPath = base_path("Modules/{$name}/src/Database/Migrations");
             if (File::exists($migrationsPath)) {
                 $migrationFiles = File::glob($migrationsPath . '/*.php');
                 foreach ($migrationFiles as $file) {
@@ -179,7 +179,7 @@ class ModuleMarketplaceCommand extends Command
                 $this->call('module:disable', ['module' => [$name], '--remove' => true]);
             }
 
-            $modulePath = base_path("modules/{$name}");
+            $modulePath = base_path("Modules/{$name}");
             if (File::exists($modulePath)) {
                 File::deleteDirectory($modulePath);
             }
@@ -227,7 +227,7 @@ class ModuleMarketplaceCommand extends Command
 
     protected function removeFromModulesConfig($name)
     {
-        $configPath = base_path('modules/Core/src/Config/modules.php');
+        $configPath = base_path('Modules/Core/src/Config/modules.php');
         if (File::exists($configPath)) {
             $config = require $configPath;
             if (isset($config['modules'])) {
@@ -263,7 +263,7 @@ class ModuleMarketplaceCommand extends Command
 
     protected function removeFromCoreConfig($name)
     {
-        $configPath = base_path('modules/Core/src/Config/config.php');
+        $configPath = base_path('Modules/Core/src/Config/config.php');
         if (File::exists($configPath)) {
             $config = require $configPath;
 
@@ -283,7 +283,7 @@ class ModuleMarketplaceCommand extends Command
         try {
             $this->info('Cleaning up orphaned module states...');
 
-            $modulePath = base_path('modules');
+            $modulePath = base_path('Modules');
             $states = ModuleState::all();
             $removedCount = 0;
 

--- a/src/Console/Commands/Actions/ModuleUseCommand.php
+++ b/src/Console/Commands/Actions/ModuleUseCommand.php
@@ -15,7 +15,7 @@ class ModuleUseCommand extends Command
     public function handle()
     {
         $moduleName = $this->argument('module');
-        $modulesPath = base_path('modules');
+        $modulesPath = base_path('Modules');
 
         if (!File::exists("{$modulesPath}/{$moduleName}")) {
             $this->error("Module '{$moduleName}' does not exist.");

--- a/src/Console/Commands/Database/Factories/MakeModuleFactory.php
+++ b/src/Console/Commands/Database/Factories/MakeModuleFactory.php
@@ -27,7 +27,7 @@ class MakeModuleFactory extends Command
         $name = $this->argument('name');
 
         // Updated path to match your structure
-        $factoryPath = base_path("modules/{$module}/src/Database/Factories");
+        $factoryPath = base_path("Modules/{$module}/src/Database/Factories");
 
         if (! $this->files->isDirectory($factoryPath)) {
             $this->files->makeDirectory($factoryPath, 0755, true);

--- a/src/Console/Commands/Database/Migrations/ModuleMigrateCommand.php
+++ b/src/Console/Commands/Database/Migrations/ModuleMigrateCommand.php
@@ -35,7 +35,7 @@ class ModuleMigrateCommand extends Command
     {
         $this->info("Running migrations for all modules...");
 
-        $modulesPath = base_path('modules');
+        $modulesPath = base_path('Modules');
 
         if (!File::exists($modulesPath)) {
             $this->warn("Modules directory not found: {$modulesPath}");
@@ -56,7 +56,7 @@ class ModuleMigrateCommand extends Command
     {
         $this->info("Migrating module [{$moduleName}]...");
 
-        $migrationPath = base_path("modules/{$moduleName}/src/Database/Migrations");
+        $migrationPath = base_path("Modules/{$moduleName}/src/Database/Migrations");
 
         if (!File::exists($migrationPath)) {
             $this->warn("No migration files found in [{$migrationPath}]");
@@ -84,7 +84,7 @@ class ModuleMigrateCommand extends Command
     {
         $this->info("Migrating single migration [{$migrationFileName}] in module [{$moduleName}]...");
 
-        $migrationPath = base_path("modules/{$moduleName}/src/Database/Migrations/{$migrationFileName}.php");
+        $migrationPath = base_path("Modules/{$moduleName}/src/Database/Migrations/{$migrationFileName}.php");
 
         if (!File::exists($migrationPath)) {
             $this->error("Migration file not found: {$migrationPath}");

--- a/src/Console/Commands/Database/Migrations/ModuleMigrateResetCommand.php
+++ b/src/Console/Commands/Database/Migrations/ModuleMigrateResetCommand.php
@@ -13,7 +13,7 @@ class ModuleMigrateResetCommand extends Command
 
     public function handle()
     {
-        $modulesPath = base_path('modules');
+        $modulesPath = base_path('Modules');
         $modules = File::directories($modulesPath);
 
         foreach ($modules as $modulePath) {

--- a/src/Console/Commands/Database/Migrations/ModuleMigrateRollbackCommand.php
+++ b/src/Console/Commands/Database/Migrations/ModuleMigrateRollbackCommand.php
@@ -30,14 +30,14 @@ class ModuleMigrateRollbackCommand extends Command
     protected function rollbackModule(string $module)
     {
         // Check both possible path cases
-        $pathLower = base_path("modules/{$module}/src/database/migrations");
-        $pathUpper = base_path("modules/{$module}/src/Database/Migrations");
+        $pathLower = base_path("Modules/{$module}/src/database/migrations");
+        $pathUpper = base_path("Modules/{$module}/src/Database/Migrations");
         
         $migrationPath = null;
         if (File::exists($pathLower)) {
-            $migrationPath = "modules/{$module}/src/database/migrations";
+            $migrationPath = "Modules/{$module}/src/database/migrations";
         } elseif (File::exists($pathUpper)) {
-            $migrationPath = "modules/{$module}/src/Database/migrations";
+            $migrationPath = "Modules/{$module}/src/Database/migrations";
         }
 
         if (!$migrationPath) {
@@ -84,7 +84,7 @@ class ModuleMigrateRollbackCommand extends Command
 
     protected function rollbackAllModules()
     {
-        $modulesPath = base_path('modules');
+        $modulesPath = base_path('Modules');
 
         if (!File::exists($modulesPath)) {
             $this->error("Modules directory not found: {$modulesPath}");

--- a/src/Console/Commands/Database/Migrations/ModuleMigrationMakeCommand.php
+++ b/src/Console/Commands/Database/Migrations/ModuleMigrationMakeCommand.php
@@ -117,7 +117,7 @@ class ModuleMigrationMakeCommand extends Command
     protected function getDestinationFilePath()
     {
         $module = $this->argument('module');
-        $path = base_path("modules/{$module}/src/Database/Migrations/");
+        $path = base_path("Modules/{$module}/src/Database/Migrations/");
         return $path . $this->getFileName() . '.php';
     }
 

--- a/src/Console/Commands/Database/Seeders/ListSeeders.php
+++ b/src/Console/Commands/Database/Seeders/ListSeeders.php
@@ -14,7 +14,7 @@ class ListSeeders extends Command
     {
         $paths = [
             database_path('seeders'), 
-            base_path('modules'),    
+            base_path('Modules'),    
         ];
 
         $seeders = [];
@@ -26,7 +26,7 @@ class ListSeeders extends Command
         }
 
         // 2. Scan modules folder for seeders
-        $modulesPath = base_path('modules');
+        $modulesPath = base_path('Modules');
         if (File::exists($modulesPath)) {
             $moduleFolders = File::directories($modulesPath);
 

--- a/src/Console/Commands/Database/Seeders/ModuleSeedCommand.php
+++ b/src/Console/Commands/Database/Seeders/ModuleSeedCommand.php
@@ -45,7 +45,7 @@ class ModuleSeedCommand extends Command
             // Check if migration path exists (try common variations)
             $possiblePaths = [
                 "Modules/{$module}/Database/Migrations",
-                "modules/{$module}/src/database/migrations",
+                "Modules/{$module}/src/database/migrations",
                 "Modules/{$module}/database/migrations"
             ];
             

--- a/src/Console/Commands/Make/MakeComponentView.php
+++ b/src/Console/Commands/Make/MakeComponentView.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace  Rcv\Core\Console\Commands\Make;
+namespace Rcv\Core\Console\Commands\Make;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -25,7 +25,7 @@ class MakeComponentView extends Command
 
         if (File::exists($filePath)) {
             $this->error("Component view already exists: {$filePath}");
-            return;
+            return 1;
         }
         $stubPath = __DIR__ . '/../stubs/component-view.stub';
 
@@ -34,5 +34,6 @@ class MakeComponentView extends Command
         File::put($filePath, $stub);
 
         $this->info("Component view created: {$component}");
+        return 0;
     }
 }

--- a/src/Console/Commands/Make/MakeJobCommand.php
+++ b/src/Console/Commands/Make/MakeJobCommand.php
@@ -16,7 +16,7 @@ class MakeJobCommand extends Command
         $module = Str::studly($this->argument('module')); // Ensures proper casing
 
         $className = class_basename($name);
-        $namespace = "Modules\\$module\\src\\User\\Jobs";
+        $namespace = "Modules\\$module\\User\\Jobs";
 
         $path = base_path("Modules/{$module}/src/User/Jobs/{$className}.php");
 

--- a/src/Console/Commands/Make/MakeMailCommand.php
+++ b/src/Console/Commands/Make/MakeMailCommand.php
@@ -29,7 +29,7 @@ class MakeMailCommand extends Command
     $name = Str::studly($this->argument('name'));
 
     // Updated path for your requirement
-    $mailPath = base_path("modules/{$module}/src/User/Mails");
+    $mailPath = base_path("Modules/{$module}/src/User/Mails");
 
     if (! $this->files->isDirectory($mailPath)) {
         $this->files->makeDirectory($mailPath, 0755, true);

--- a/src/Console/Commands/Make/MakeModuleArtisanCommand.php
+++ b/src/Console/Commands/Make/MakeModuleArtisanCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace  Rcv\Core\Console\Commands\Make;
+namespace Rcv\Core\Console\Commands\Make;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -26,7 +26,7 @@ class MakeModuleArtisanCommand extends Command
 
         if (File::exists($filePath)) {
             $this->error("Command already exists: {$filePath}");
-            return;
+            return 1;
         }
 
                  $stubPath = __DIR__ . '/../stubs/console-command.stub';
@@ -48,5 +48,6 @@ class MakeModuleArtisanCommand extends Command
 
         File::put($filePath, $content);
         $this->info("Command created: {$filePath}");
+        return 0;
     }
 }

--- a/src/Console/Commands/Make/MakeModuleClass.php
+++ b/src/Console/Commands/Make/MakeModuleClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace  Rcv\Core\Console\Commands\Make;
+namespace Rcv\Core\Console\Commands\Make;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -21,8 +21,8 @@ class MakeModuleClass extends Command
         $subPath = dirname($classPath) !== '.' ? dirname($classPath) : '';
         $namespace = "Modules\\{$module}" . ($subPath ? '\\' . str_replace('/', '\\', $subPath) : '');
 
-        $directory = base_path("Modules/{$module}/src/Class" . ($subPath ? '/' . $subPath : ''));
-        $fileName = basename($classPath) . '.php';
+        $directory = base_path("Modules/{$module}/src" . ($subPath ? '/' . $subPath : ''));
+        $fileName = $className . '.php';
         $filePath = "{$directory}/{$fileName}";
 
         if (!File::exists($directory)) {
@@ -31,7 +31,7 @@ class MakeModuleClass extends Command
 
         if (File::exists($filePath)) {
             $this->error("Class already exists: {$filePath}");
-            return;
+            return 1;
         }
 
         // Use stub located inside the same directory as this command
@@ -52,5 +52,6 @@ class MakeModuleClass extends Command
 
         File::put($filePath, $content);
         $this->info("Class created: {$filePath}");
+        return 0;
     }
 }

--- a/src/Console/Commands/Make/MakeModuleComponent.php
+++ b/src/Console/Commands/Make/MakeModuleComponent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace  Rcv\Core\Console\Commands\Make;
+namespace Rcv\Core\Console\Commands\Make;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -36,7 +36,7 @@ class MakeModuleComponent extends Command
 
         // View file directory and file
     // Correct view file directory inside src
-    $viewDir = $basePath . '/src/resources/views/components' . ($folderPath ? '/' . $folderPath : '');
+    $viewDir = $basePath . '/src/Resources/views/components' . ($folderPath ? '/' . $folderPath : '');
     $viewFile = $viewDir . '/' . \Illuminate\Support\Str::kebab($className) . '.blade.php';
 
 

--- a/src/Console/Commands/Make/MakeModuleNotification.php
+++ b/src/Console/Commands/Make/MakeModuleNotification.php
@@ -16,7 +16,7 @@ class MakeModuleNotification extends Command
         $module = Str::studly($this->argument('module'));
         $name = Str::studly($this->argument('name'));
 
-        $moduleBasePath = base_path("modules/{$module}");
+        $moduleBasePath = base_path("Modules/{$module}");
 
         // Validate module existence
         if (!File::exists($moduleBasePath)) {

--- a/src/Console/Commands/Make/MakeModuleObserver.php
+++ b/src/Console/Commands/Make/MakeModuleObserver.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace  Rcv\Core\Console\Commands\Make;
+namespace Rcv\Core\Console\Commands\Make;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -26,7 +26,7 @@ class MakeModuleObserver extends Command
 
         if (File::exists($filePath)) {
             $this->error("Observer already exists: {$filePath}");
-            return;
+            return 1;
         }
 
          $stubPath = __DIR__ . '/../stubs/observer.stub';
@@ -46,5 +46,6 @@ class MakeModuleObserver extends Command
 
         File::put($filePath, $content);
         $this->info("Observer created: {$filePath}");
+        return 0;
     }
 }

--- a/src/Console/Commands/Make/MakeModulePolicy.php
+++ b/src/Console/Commands/Make/MakeModulePolicy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace  Rcv\Core\Console\Commands\Make;
+namespace Rcv\Core\Console\Commands\Make;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -26,7 +26,7 @@ class MakeModulePolicy extends Command
 
         if (File::exists($filePath)) {
             $this->error("Policy already exists: {$filePath}");
-            return;
+            return 1;
         }
 
          $stubPath = __DIR__ . '/../stubs/policy.stub';
@@ -46,5 +46,6 @@ class MakeModulePolicy extends Command
 
         File::put($filePath, $content);
         $this->info("Policy class created: {$filePath}");
+        return 0;
     }
 }

--- a/src/Console/Commands/Make/MakeModuleRequest.php
+++ b/src/Console/Commands/Make/MakeModuleRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace  Rcv\Core\Console\Commands\Make;
+namespace Rcv\Core\Console\Commands\Make;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -17,7 +17,7 @@ class MakeModuleRequest extends Command
         $module = Str::studly($this->argument('module'));
 
         $namespace = "Modules\\{$module}\\Http\\Requests";
-        $path = base_path("modules/{$module}/src/Http/Requests");
+        $path = base_path("Modules/{$module}/src/Http/Requests");
 
         $filePath = "{$path}/{$name}.php";
 

--- a/src/Console/Commands/Make/MakeModuleTrait.php
+++ b/src/Console/Commands/Make/MakeModuleTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace  Rcv\Core\Console\Commands\Make;
+namespace Rcv\Core\Console\Commands\Make;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
@@ -26,7 +26,7 @@ class MakeModuleTrait extends Command
 
         if (File::exists($filePath)) {
             $this->error("Trait already exists: {$filePath}");
-            return;
+            return 1;
         }
 
          $stubPath = __DIR__ . '/../stubs/trait.stub';
@@ -46,5 +46,6 @@ class MakeModuleTrait extends Command
 
         File::put($filePath, $content);
         $this->info("Trait created: {$filePath}");
+        return 0;
     }
 }

--- a/src/Console/Commands/Make/ModuleEventProviderCommand.php
+++ b/src/Console/Commands/Make/ModuleEventProviderCommand.php
@@ -20,13 +20,13 @@ class ModuleEventProviderCommand extends Command
         $module = $this->argument('module');
 
         // Ensure module exists
-        if (!File::exists(base_path("modules/{$module}"))) {
+        if (!File::exists(base_path("Modules/{$module}"))) {
             $this->error("Module {$module} does not exist.");
             return 1;
         }
 
         // Create provider directory if it doesn't exist
-        $providerPath = base_path("modules/{$module}/src/Providers");
+        $providerPath = base_path("Modules/{$module}/src/Providers");
         if (!File::exists($providerPath)) {
             File::makeDirectory($providerPath, 0755, true);
         }

--- a/src/Console/Commands/Make/ModuleMakeCommand.php
+++ b/src/Console/Commands/Make/ModuleMakeCommand.php
@@ -40,7 +40,7 @@ class ModuleMakeCommand extends Command
         $this->moduleName = $name;
         $this->moduleNameStudly = Str::studly($name);
         $this->moduleNameLower = strtolower(preg_replace('/[^a-zA-Z0-9]/', '', $name));
-        $this->modulePath = base_path("modules/{$this->moduleNameStudly}");
+        $this->modulePath = base_path("Modules/{$this->moduleNameStudly}");
     }
 
     protected function createModuleDirectories(): void
@@ -125,7 +125,7 @@ class ModuleMakeCommand extends Command
             return;
         }
 
-        $composer['autoload']['psr-4']["Modules\\{$this->moduleNameStudly}\\"] = "modules/{$this->moduleNameStudly}/src/";
+        $composer['autoload']['psr-4']["Modules\\{$this->moduleNameStudly}\\"] = "Modules/{$this->moduleNameStudly}/src/";
         File::put($composerPath, json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
 

--- a/src/Console/Commands/Make/ModuleMakeMultipleCommand.php
+++ b/src/Console/Commands/Make/ModuleMakeMultipleCommand.php
@@ -52,7 +52,7 @@ class ModuleMakeMultipleCommand extends Command
 
     protected function addToMarketplace(string $moduleName): void
     {
-        $marketplaceFile = base_path('modules/Core/marketplace.json');
+        $marketplaceFile = base_path('Modules/Core/marketplace.json');
         $marketplace = File::exists($marketplaceFile)
             ? json_decode(File::get($marketplaceFile), true)
             : ['modules' => []];
@@ -68,7 +68,7 @@ class ModuleMakeMultipleCommand extends Command
 
     protected function updateModuleStatus(string $moduleLower, bool $enabled): void
     {
-        $filePath = base_path("modules/{$moduleLower}/module.json");
+        $filePath = base_path("Modules/{$moduleLower}/module.json");
 
         if (!File::exists($filePath)) {
             $this->error(" module.json not found for [$moduleLower].");

--- a/src/Console/Commands/Make/ModuleMakeViewCommand.php
+++ b/src/Console/Commands/Make/ModuleMakeViewCommand.php
@@ -67,6 +67,6 @@ class ModuleMakeViewCommand extends Command
 
         $viewPath = str_replace('.', '/', $view) . '.blade.php';
 
-        return base_path("Modules/{$module}/src/resources/views/{$viewPath}");
+        return base_path("Modules/{$module}/src/Resources/views/{$viewPath}");
     }
 }

--- a/src/Console/Commands/Make/ModuleMiddlewareCommand.php
+++ b/src/Console/Commands/Make/ModuleMiddlewareCommand.php
@@ -21,7 +21,7 @@ class ModuleMiddlewareCommand extends Command
         $module = $this->argument('module');
 
         // Correct path to the middleware folder inside module
-        $middlewarePath = base_path("modules/{$module}/src/Http/Middleware");
+        $middlewarePath = base_path("Modules/{$module}/src/Http/Middleware");
         $filePath = "{$middlewarePath}/{$name}.php";
 
         if (!is_dir($middlewarePath)) {

--- a/src/Console/Commands/ModuleAutoloadCommand.php
+++ b/src/Console/Commands/ModuleAutoloadCommand.php
@@ -61,7 +61,7 @@ class ModuleAutoloadCommand extends Command
      */
     public function handle()
     {
-        $modulesPath = base_path('modules');
+        $modulesPath = base_path('Modules');
         $modules = File::directories($modulesPath);
         
         $composerJson = json_decode(File::get(base_path('composer.json')), true);
@@ -74,7 +74,7 @@ class ModuleAutoloadCommand extends Command
         
         // Add Core module back if not present
         if (!isset($autoload['Modules\\Core\\'])) {
-            $autoload['Modules\\Core\\'] = 'modules/Core/src/';
+            $autoload['Modules\\Core\\'] = 'Modules/Core/src/';
         }
         
         // Update composer.json

--- a/src/Console/Commands/ModuleStateCommand.php
+++ b/src/Console/Commands/ModuleStateCommand.php
@@ -13,7 +13,7 @@ class ModuleStateCommand extends Command
     public function handle()
     {
         $name = $this->argument('name');
-        $modulePath = base_path('modules');
+        $modulePath = base_path('Modules');
 
         if ($name) {
             $state = ModuleState::where('name', $name)->first();

--- a/src/Console/Commands/Publish/ModulePublishConfig.php
+++ b/src/Console/Commands/Publish/ModulePublishConfig.php
@@ -17,7 +17,7 @@ class ModulePublishConfig extends Command
     {
         $module = $this->argument('module') ?? $this->ask('Please provide the module name');
 
-        $moduleConfigPath = base_path("modules/{$module}/src/Config");
+        $moduleConfigPath = base_path("Modules/{$module}/src/Config");
         $appConfigPath = config_path("{$module}");
 
         if (!File::exists($moduleConfigPath)) {

--- a/src/Console/Commands/Publish/ModulePublishMigration.php
+++ b/src/Console/Commands/Publish/ModulePublishMigration.php
@@ -15,7 +15,7 @@ class ModulePublishMigration extends Command
     {
         $module = $this->argument('module');
 
-        $moduleMigrationPath = base_path("modules/{$module}/src/database/migrations");
+        $moduleMigrationPath = base_path("Modules/{$module}/src/database/migrations");
         $appMigrationPath = database_path('migrations');
 
         if (!File::exists($moduleMigrationPath)) {

--- a/src/Console/Commands/stubs/database-seeder.stub
+++ b/src/Console/Commands/stubs/database-seeder.stub
@@ -2,8 +2,6 @@
 
 namespace Modules\{{ module_name }}\Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class {{ module_name }}DatabaseSeeder extends Seeder
@@ -13,11 +11,6 @@ class {{ module_name }}DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        // Add module seeders here, e.g. $this->call(ExampleSeeder::class);
     }
 }

--- a/src/Console/Commands/stubs/service.stub
+++ b/src/Console/Commands/stubs/service.stub
@@ -3,6 +3,7 @@
 namespace Modules\{{ module_name }}\Services;
 
 use Rcv\Core\Services\BaseService as CoreBaseService;
+use Modules\{{ module_name }}\Repositories\{{ class_name }}Repository;
 
  
 class {{ class_name }}Service extends CoreBaseService

--- a/src/Providers/CoreServiceProvider.php
+++ b/src/Providers/CoreServiceProvider.php
@@ -247,6 +247,48 @@ class CoreServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->commands($this->commands);
+
+            // Attach module seeders to default db:seed
+            \Illuminate\Support\Facades\Event::listen(\Illuminate\Console\Events\CommandFinished::class, function ($event) {
+                static $rcvSeedingModules = false;
+                if ($rcvSeedingModules) {
+                    return;
+                }
+
+                if ($event->command === 'db:seed') {
+                    // Only run when no specific class is provided
+                    $input = $event->input ?? null;
+                    if ($input && $input->getOption('class')) {
+                        return;
+                    }
+
+                    $modulesPath = base_path('Modules');
+                    if (!\Illuminate\Support\Facades\File::exists($modulesPath)) {
+                        return;
+                    }
+
+                    $rcvSeedingModules = true;
+                    try {
+                        foreach (\Illuminate\Support\Facades\File::directories($modulesPath) as $moduleDir) {
+                            $moduleName = basename($moduleDir);
+                            $seederClass = "Modules\\\\{$moduleName}\\\\Database\\\\Seeders\\\\{$moduleName}DatabaseSeeder";
+                            if (class_exists($seederClass)) {
+                                try {
+                                    \Illuminate\Support\Facades\Artisan::call('db:seed', [
+                                        '--class' => $seederClass,
+                                        '--force' => true,
+                                    ]);
+                                    $this->app['log']->info("Seeded module: {$moduleName}");
+                                } catch (\Throwable $t) {
+                                    $this->app['log']->error("Failed seeding module {$moduleName}: " . $t->getMessage());
+                                }
+                            }
+                        }
+                    } finally {
+                        $rcvSeedingModules = false;
+                    }
+                }
+            });
         }
     }
 
@@ -269,7 +311,7 @@ class CoreServiceProvider extends ServiceProvider
      */
     protected function registerViews(): void
     {
-        $viewPath = base_path('modules/Core/src/Resources/views');
+        $viewPath = base_path('Modules/Core/src/Resources/views');
         
         if (File::exists($viewPath)) {
             $this->loadViewsFrom($viewPath, 'core');

--- a/src/Providers/ModuleServiceProvider.php
+++ b/src/Providers/ModuleServiceProvider.php
@@ -94,7 +94,7 @@ abstract class ModuleServiceProvider extends ServiceProvider
     protected function registerConfig(): void
     {
         $moduleName = $this->getModuleName();
-        $configPath = base_path("modules/{$moduleName}/src/Config/config.php");
+        $configPath = base_path("Modules/{$moduleName}/src/Config/config.php");
         
         if (File::exists($configPath)) {
             $this->mergeConfigFrom($configPath, strtolower($moduleName));
@@ -189,8 +189,8 @@ abstract class ModuleServiceProvider extends ServiceProvider
     protected function registerRoutes(): void
     {
         $moduleName = $this->getModuleName();
-        $webRoutePath = realpath(base_path("modules/{$moduleName}/src/Routes/web.php"));
-        $apiRoutePath = realpath(base_path("modules/{$moduleName}/src/Routes/api.php"));
+        $webRoutePath = realpath(base_path("Modules/{$moduleName}/src/Routes/web.php"));
+        $apiRoutePath = realpath(base_path("Modules/{$moduleName}/src/Routes/api.php"));
 
         if ($webRoutePath && File::exists($webRoutePath)) {
             Route::middleware('web')
@@ -230,7 +230,7 @@ abstract class ModuleServiceProvider extends ServiceProvider
     protected function getMigrationsPath(): string
     {
         $moduleName = $this->getModuleName();
-        return base_path("modules/{$moduleName}/src/Database/Migrations");
+        return base_path("Modules/{$moduleName}/src/Database/Migrations");
     }
 
     /**
@@ -239,7 +239,7 @@ abstract class ModuleServiceProvider extends ServiceProvider
     protected function getViewsPath(): string
     {
         $moduleName = $this->getModuleName();
-        return base_path("modules/{$moduleName}/src/Resources/views");
+        return base_path("Modules/{$moduleName}/src/Resources/views");
     }
 
     /**
@@ -248,7 +248,7 @@ abstract class ModuleServiceProvider extends ServiceProvider
     protected function getConfigPath(): string
     {
         $moduleName = $this->getModuleName();
-        return base_path("modules/{$moduleName}/src/Config/config.php");
+        return base_path("Modules/{$moduleName}/src/Config/config.php");
     }
 
     /**
@@ -257,7 +257,7 @@ abstract class ModuleServiceProvider extends ServiceProvider
     protected function getAssetsPath(): string
     {
         $moduleName = $this->getModuleName();
-        return base_path("modules/{$moduleName}/src/Resources/assets");
+        return base_path("Modules/{$moduleName}/src/Resources/assets");
     }
 
     protected function registerMiddlewareManager()

--- a/src/Services/MarketplaceService.php
+++ b/src/Services/MarketplaceService.php
@@ -35,11 +35,11 @@ class MarketplaceService
         ModuleRegistrationService $moduleRegistrationService
     )
     {
-        $this->localPath = Config::get('marketplace.local.path', base_path('modules'));
+        $this->localPath = Config::get('marketplace.local.path', base_path('Modules'));
         $this->cacheEnabled = Config::get('marketplace.cache.enabled', true);
         $this->cacheTtl = Config::get('marketplace.cache.ttl', 3600);
         $this->backupPath = Config::get('marketplace.modules.backup.path', storage_path('app/modules/backups'));
-        $this->modulePath = base_path('modules');
+        $this->modulePath = base_path('Modules');
         $this->config = config('marketplace');
         $this->cacheManager = $cacheManager;
         $this->moduleRegistrationService = $moduleRegistrationService;

--- a/src/Services/ModuleHealthCheck.php
+++ b/src/Services/ModuleHealthCheck.php
@@ -17,7 +17,7 @@ class ModuleHealthCheck
     public function __construct(MarketplaceService $marketplaceService)
     {
         $this->marketplaceService = $marketplaceService;
-        $this->modulePath = base_path('modules');
+        $this->modulePath = base_path('Modules');
     }
 
     public function check()

--- a/src/Services/ModuleLoader.php
+++ b/src/Services/ModuleLoader.php
@@ -15,7 +15,7 @@ class ModuleLoader
     
     public function __construct()
     {
-        $this->modulePath = base_path('modules');
+        $this->modulePath = base_path('Modules');
     }
     
     public function loadModules()

--- a/src/Services/ModuleManager.php
+++ b/src/Services/ModuleManager.php
@@ -16,7 +16,7 @@ class ModuleManager
     
     public function __construct()
     {
-        $this->modulePath = base_path('modules');
+        $this->modulePath = base_path('Modules');
         $this->initialize();
     }
     
@@ -74,7 +74,7 @@ class ModuleManager
     protected function scanAvailableModules(): array
     {
         $modules = [];
-        $modulesPath = base_path('modules');
+        $modulesPath = base_path('Modules');
 
         if (File::exists($modulesPath)) {
             $directories = File::directories($modulesPath);
@@ -156,7 +156,7 @@ class ModuleManager
      */
     public function getModuleState(string $moduleName): array
     {
-        $moduleJsonPath = base_path("modules/{$moduleName}/module.json");
+        $moduleJsonPath = base_path("Modules/{$moduleName}/module.json");
         
         if (File::exists($moduleJsonPath)) {
             $config = json_decode(File::get($moduleJsonPath), true);
@@ -223,7 +223,7 @@ class ModuleManager
      */
     protected function updateModuleState(string $moduleName, array $state): void
     {
-        $moduleJsonPath = base_path("modules/{$moduleName}/module.json");
+        $moduleJsonPath = base_path("Modules/{$moduleName}/module.json");
         File::put($moduleJsonPath, json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
     
@@ -235,7 +235,7 @@ class ModuleManager
      */
     protected function isValidModule(string $moduleName): bool
     {
-        $modulePath = base_path("modules/{$moduleName}");
+        $modulePath = base_path("Modules/{$moduleName}");
         $moduleJsonPath = "{$modulePath}/module.json";
         $providerPath = "{$modulePath}/src/Providers/{$moduleName}ServiceProvider.php";
 

--- a/src/Services/ModuleRegistrationService.php
+++ b/src/Services/ModuleRegistrationService.php
@@ -13,7 +13,7 @@ class ModuleRegistrationService
     public function __construct()
     {
         $this->appConfigPath = config_path('app.php');
-        $this->modulePath = base_path('modules');
+        $this->modulePath = base_path('Modules');
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -10,7 +10,7 @@ if (!function_exists('module_path')) {
      */
     function module_path($module, $path = '')
     {
-        $modulePath = base_path('modules/' . $module);
+        $modulePath = base_path('Modules/' . $module);
         return $path ? $modulePath . '/' . ltrim($path, '/') : $modulePath;
     }
 }


### PR DESCRIPTION
…odule seeding integration Switch all filesystem references to case-sensitive Modules/ across providers, services, helpers, and commands Add subdirectory-aware generation for controllers, models, repositories, services, enums, components, and views with correct PSR-4 namespaces Fix undefined variables in make commands (e.g., use  not ), and normalize success/error outputs Add already exists checks with proper exit codes and paths across make commands Ensure generated namespaces match nested directory structure (e.g., Models/Domain → Modules\Foo\Models\Domain) Update stubs: service.stub imports the correct repository (including subpaths) repository.stub generates <Name>Repository and returns the correct class from model() database-seeder.stub cleaned to neutral template Integrate module seeders with default php artisan db:seed (runs each module’s <Module>DatabaseSeeder when no --class provided) Fix ModuleAutoloadCommand to use Modules/Core/src/ PSR-4 path Correct MakeJobCommand namespace (remove src from namespace) Fix view paths to src/Resources/views README: document module:marketplace actions and usage with examples; improve command docs